### PR TITLE
Use lowercase internal dependency names

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -32,7 +32,7 @@
     <url type="documentation">https://github.com/mnesarco/SvgWorkbench/wiki/</url>
     <url type="readme">https://github.com/mnesarco/SvgWorkbench/blob/main/README.md</url>
     <url type="repository" branch="main">https://github.com/mnesarco/SvgWorkbench/</url>
-    <depend type="internal">Draft</depend>
-    <depend type="internal">Part</depend>
-    <depend type="internal">TechDraw</depend>
+    <depend type="internal">draft</depend>
+    <depend type="internal">part</depend>
+    <depend type="internal">techdraw</depend>
 </package>


### PR DESCRIPTION
Same as in channels -- I'll fix the Addon Manager, this was a mistake on my part, but for backwards compatibility you might want to consider merging this PR.